### PR TITLE
Allow `base-compat-0.14.1`.

### DIFF
--- a/monad-schedule.cabal
+++ b/monad-schedule.cabal
@@ -31,7 +31,7 @@ source-repository head
 common deps
   build-depends:
     , base          >=4.16.0 && <4.21.0
-    , base-compat   ^>=0.13
+    , base-compat   >=0.13 && < 0.15
     , free          >=5.1 && < 5.3
     , stm           ^>=2.5
     , time-domain   ^>=0.1


### PR DESCRIPTION
Should be enough to re-eanble this package on stackage. Maybe this is even a change that could/should be done as a hackage revision.